### PR TITLE
BATIAI-1010 - Add nat gateway to alb security group so that it can be hit by other EKS services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,15 @@ resource "aws_security_group_rule" "ingress_prefix_list" {
   prefix_list_ids   = var.ingress_prefix_lists
   security_group_id = aws_security_group.alb_sg.id
 }
+resource "aws_security_group_rule" "ingress_gateway_nat" {
+  count             = length(var.nat_gateway_public_ip_cidrs) > 0 ? 1 : 0
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.nat_gateway_public_ip_cidrs
+  security_group_id = data.aws_security_group.default_USSBA_fargate_security_group.id
+}
 
 data "aws_iam_policy_document" "fargate" {
   statement {
@@ -181,4 +190,8 @@ resource "aws_security_group_rule" "allow_fargate_into_efs" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.efs.id
   source_security_group_id = module.gatus.security_group_id
+}
+
+data "aws_security_group" "default_USSBA_fargate_security_group" {
+  name = "${var.service_name}-alb"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,9 @@ variable "kms_key_id" {
   description = "For encrypting the EFS drive; defaults to the aws managed efs key"
   type        = string
 }
+
+variable "nat_gateway_public_ip_cidrs" {
+  type        = list(any)
+  default     = []
+  description = "For allowing the nat gateway public ips to reach Gatus"
+}


### PR DESCRIPTION
## Description:

Add nat gateway to alb security group so that it can be hit by other EKS services in the private subnet 

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
